### PR TITLE
Compile firmware in CI

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -1,0 +1,65 @@
+name: Build firmware
+
+on:
+  pull_request:
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        permissions:
+          actions: read
+          contents: read
+        steps:
+        - uses: actions/checkout@v6
+        - name: Get branch name
+          id: branch-name
+          uses: tj-actions/branch-names@v9
+        - name: Get last successful workflow run
+          uses: SamhammerAG/last-successful-build-action@v7
+          id: last_successful_commit_push
+          with:
+            branch: ${{ steps.branch-name.outputs.current_branch }} # Get the last successful commit for the current branch.
+            workflow: "Build firmware"
+            fallbackToEarliestSha: true # If SHA of last successful commit can not be determined, use earliest (true) or triggering sha (false)
+        - name: Get changed files since last successful workflow run
+          id: changed-files
+          uses: tj-actions/changed-files@v47
+          with:
+            # Avoid using single or double quotes for multiline patterns
+            files: |
+              .github/workflows/firmware.yml
+              example/matouch_knob/*.*
+            base_sha: ${{ steps.last_successful_commit_push.outputs.sha }}
+        - name: List firmware-related file changes
+          env:
+            ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+          run: |
+            for file in ${ALL_CHANGED_FILES}; do
+              echo "$file was changed"
+            done
+        - name: Compile sketch
+          id: compile-sketch
+          uses: arduino/compile-sketches@v1
+          if: steps.changed-files.outputs.any_changed == 'true'
+          with:
+            platforms: |
+              - name: "esp32:esp32"
+                version: 2.0.17
+            libraries: |
+              - name: ArduinoJson
+                version: 7.0.4
+              - name: AsyncTCP
+                version: 1.1.4
+              - name: ESPAsyncWebSrv
+                version: 1.2.7
+              - name: GFX Library for Arduino
+                version: 1.3.1
+              - name: lvgl
+                version: 8.3.11
+              - name: OneButton
+                version: 2.5.0
+              - name: Simple FOC
+                version: 2.3.2
+            sketch-paths: |
+              - example/matouch_knob/
+            fqbn: "esp32:esp32:esp32s3:CDCOnBoot=cdc,CPUFreq=240,FlashMode=qio,FlashSize=16M,PartitionScheme=app3M_fat9M_16MB,PSRAM=opi,LoopCore=1,EventsCore=1" # from build.options.json in sketch build folder, without default/upload options: UploadSpeed=921600,USBMode=default,MSCOnBoot=default,DFUOnBoot=default,UploadMode=default,JTAGAdapter=default,DebugLevel=none,EraseFlash=all

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@ Inspired by [Scott Bezek](https://github.com/scottbez1)'s [SmartKnob](https://gi
 
 The [SHIVERS Group](https://github.com/ucalgary-shivers) at the University of Calgary brings new software features:
 - updated documentation
+- firmware compilation verified via Continuous Integration with [.github/workflows/firmware.yml](.github/workflows/firmware.yml)
 
 ## Hardware Features
 
@@ -66,6 +67,7 @@ The [SHIVERS Group](https://github.com/ucalgary-shivers) at the University of Ca
   - USB Mode: "USB-OTG (TinyUSB)"
 - Compile.
 - Tools > Port: select your device.
+  - Note: compilation is verified via Continuous Integration with [.github/workflows/firmware.yml](.github/workflows/firmware.yml), please update documentation and workflow accordingly.
 - Upload.
 
 ## Provenance


### PR DESCRIPTION
Closes: #2

## Changelog

- Compile sketch in CI with https://github.com/arduino/compile-sketches if needed by relevant file changes since last successful workflow run.
  - Get last successful workflow run with https://github.com/SamhammerAG/last-successful-build-action/tree/v7/
  - Get changed files since last successful workflow run with https://github.com/tj-actions/changed-files/tree/v47/ 
- Define `-DLV_CONF_SKIP` in `example/matouch_knob/build_opt.h` to remove the need of `libraries/lvgl/src/lv_conf.h` based on the following minor differences:
   - [lvgl/lv\_conf\_template.h at v8.3.2 · lvgl/lvgl · GitHub](https://github.com/lvgl/lvgl/blob/v8.3.2/lv_conf_template.h) (version mentioned  in https://github.com/ucalgary-shivers/Makerfabs-MaTouch-Knob/blob/main/libraries/lvgl/src/lv_conf.h)
      - only difference is `#define LV_TICK_CUSTOM 0` in Makerfabs vs `1` in template
  - [lvgl/lv\_conf\_template.h at v8.3.11 · lvgl/lvgl · GitHub](https://github.com/lvgl/lvgl/blob/v8.3.11/lv_conf_template.h) (installed library version)
    - template has `#define LV_TICK_CUSTOM 0`